### PR TITLE
remote MCP server

### DIFF
--- a/atla-mcp-server.py
+++ b/atla-mcp-server.py
@@ -102,7 +102,7 @@ def list_metrics() -> List[Dict[str, str]]:
             - "description": A brief description of what the metric measures or evaluates.
     """
     metrics = atla_client.metrics.list().metrics
-    return [{"id": m.id, "name": m.name, "description": m.description} for m in metrics]
+    return [{"name": m.name, "description": m.description} for m in metrics]
 
 @mcp.tool()
 def create_metric(


### PR DESCRIPTION
use `sse` transport instead of `stdio` - this lets MCP servers talk to `localhost:8000` using the `mcp-remote` package as follows:
```shell
npx mcp-remote http://localhost:8000/sse --header "Authorization: Bearer $ATLA_API_KEY"
```

**Context**
https://www.npmjs.com/package/mcp-remote

**Steps**
- You'll need to install this repository (including the Node dependencies `npm install mcp-remote`)
- You'll need to "run" `atla-mcp-server.py` to host the server locally `uv run atla-mcp-server.py` (this is specified inside the .py using uvicorn) 
- You'll then need to expose the localhost url globally somehow - for e.g. if I use `ngrok` then I might add the following to my Claude Desktop


```json
{
    "mcpServers": {
      "atla-mcp-server": {
      "command": "npx",
      "args": [
        "mcp-remote",
        "https://my-ngrok-url.app/sse",
        "--header",
        "Authorization: Bearer ${ATLA_API_KEY}"
      ],
      "env": {
        "ATLA_API_KEY": "your_actual_api_key"
      }
    }
    }
   }
```