### PR TITLE
[linting] sync ruff version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.9.7
     hooks:
       # Run the linter
       - id: ruff


### PR DESCRIPTION
the version in pre-commit didn't match pyproject.toml