### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ An MCP server implementation providing a standardized interface for LLMs to inte
 
 > Learn more about Atla [here](https://www.docs.atla-ai.com). Learn more about the Model Context Protocol [here](https://modelcontextprotocol.io).
 
+<a href="https://glama.ai/mcp/servers/@atla-ai/atla-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@atla-ai/atla-mcp-server/badge" alt="Atla MCP server" />
+</a>
+
 ## Available Tools
 
 - `evaluate_llm_response`: Evaluate an LLM's response to a prompt using a given evaluation criteria. This function uses an Atla evaluation model under the hood to return a dictionary containing a score for the model's response and a textual critique containing feedback on the model's response.


### PR DESCRIPTION
This PR adds a badge for the [Atla](https://glama.ai/mcp/servers/@atla-ai/atla-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@atla-ai/atla-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@atla-ai/atla-mcp-server/badge" alt="Atla MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.